### PR TITLE
feat: add World Cup edition filter with host/champion badges

### DIFF
--- a/openspec/changes/add-world-cup-filter/tasks.md
+++ b/openspec/changes/add-world-cup-filter/tasks.md
@@ -2,28 +2,28 @@
 
 ## 1. World Cup dataset
 
-- [ ] 1.1 Create `src/assets/world-cups.json` with all 23 editions 1930–2026 (year, hosts, champion, participants as alpha-3 codes; `champion: null` for 2026), sourcing participants from FIFA's official records
-- [ ] 1.2 Map teams without own ISO codes and deduplicate per edition: defunct states (West Germany and East Germany→DEU, USSR→RUS, Czechoslovakia→CZE, Yugoslavia→SRB, Zaire→COD, Dutch East Indies→IDN, Serbia and Montenegro→SRB) and UK home nations (England/Scotland/Wales/Northern Ireland→GBR); record `historicalName` for them
-- [ ] 1.3 Validate every participant/host/champion code against `src/assets/data.json` (no orphan codes — including CUW for Curaçao, 2026 debutant) and verify anchor facts: 1930 = URY host+champion with 13 participants, 1966 = GBR host+champion, 2002 hosts KOR+JPN, 2022 champion ARG, 2026 hosts USA+MEX+CAN with `champion: null`
+- [x] 1.1 Create `src/assets/world-cups.json` with all 23 editions 1930–2026 (year, hosts, champion, participants as alpha-3 codes; `champion: null` for 2026), sourcing participants from FIFA's official records
+- [x] 1.2 Map teams without own ISO codes and deduplicate per edition: defunct states (West Germany and East Germany→DEU, USSR→RUS, Czechoslovakia→CZE, Yugoslavia→SRB, Zaire→COD, Dutch East Indies→IDN, Serbia and Montenegro→SRB) and UK home nations (England/Scotland/Wales/Northern Ireland→GBR); record `historicalName` for them
+- [x] 1.3 Validate every participant/host/champion code against `src/assets/data.json` (no orphan codes — including CUW for Curaçao, 2026 debutant) and verify anchor facts: 1930 = URY host+champion with 13 participants, 1966 = GBR host+champion, 2002 hosts KOR+JPN, 2022 champion ARG, 2026 hosts USA+MEX+CAN with `champion: null`
 
 ## 2. World Cup catalog service
 
-- [ ] 2.1 Create `WorldCupViewModel` (and edition model) in `src/app/features/home/shared/models/world-cups.model.ts`
-- [ ] 2.2 Create root-provided `WorldCupService` in `src/app/features/home/shared/world-cup.service.ts` loading the asset via HttpClient with `shareReplay(1)`, exposing editions ordered by year descending
+- [x] 2.1 Create `WorldCupViewModel` (and edition model) in `src/app/features/home/shared/models/world-cups.model.ts`
+- [x] 2.2 Create root-provided `WorldCupService` in `src/app/features/home/shared/world-cup.service.ts` loading the asset via HttpClient with `shareReplay(1)`, exposing editions ordered by year descending
 
 ## 3. Filtering
 
-- [ ] 3.1 Extend `CountryDataService.filter` with an optional `worldCupYear` parameter that intersects countries with the selected edition's participant `Set` (conjunctive with name and region)
-- [ ] 3.2 Add the `worldCup` control to `searchForm` in `HomeComponent` and forward its value through the existing `valueChanges` pipeline
-- [ ] 3.3 Add the "World Cup" Material select to the home filter bar listing editions (label: year + host names), with an empty option, styled per the existing region select
-- [ ] 3.4 Extend the existing clear-filter behavior to also reset the `worldCup` control
+- [x] 3.1 Extend `CountryDataService.filter` with an optional `worldCupYear` parameter that intersects countries with the selected edition's participant `Set` (conjunctive with name and region)
+- [x] 3.2 Add the `worldCup` control to `searchForm` in `HomeComponent` and forward its value through the existing `valueChanges` pipeline
+- [x] 3.3 Add the "World Cup" Material select to the home filter bar listing editions (label: year + host names), with an empty option, styled per the existing region select
+- [x] 3.4 Extend the existing clear-filter behavior to also reset the `worldCup` control
 
 ## 4. Host/champion badges
 
-- [ ] 4.1 Add an optional `worldCupRole` input (`'host' | 'champion' | 'host-champion'`) to `CountryCardComponent` and render badges over the flag, themed for light and dark modes
-- [ ] 4.2 Compute each country's role in `HomeComponent` from the selected edition (champion only when not `null`) and pass it to the cards; no role when no edition is selected
+- [x] 4.1 Add an optional `worldCupRole` input (`'host' | 'champion' | 'host-champion'`) to `CountryCardComponent` and render badges over the flag, themed for light and dark modes
+- [x] 4.2 Compute each country's role in `HomeComponent` from the selected edition (champion only when not `null`) and pass it to the cards; no role when no edition is selected
 
 ## 5. Verification
 
-- [ ] 5.1 Run `npm run build` and fix any errors (strict templates)
-- [ ] 5.2 Manually verify spec scenarios: 1930 → 13 countries with URY double badge; 2022 + region Europe → only European participants; 2026 → three host badges, no champion; clear filters resets the edition
+- [x] 5.1 Run `npm run build` and fix any errors (strict templates)
+- [x] 5.2 Manually verify spec scenarios: 1930 → 13 countries with URY double badge; 2022 + region Europe → only European participants; 2026 → three host badges, no champion; clear filters resets the edition

--- a/src/app/features/home/components/country-card/country-card.component.html
+++ b/src/app/features/home/components/country-card/country-card.component.html
@@ -3,12 +3,22 @@
   class="country-card"
   (click)="handleCountryDetail()"
 >
-  <img
-    mat-card-image
-    class="country-card-image"
-    [src]="country.flags.png"
-    [alt]="country.name"
-  />
+  <div class="country-card-flag">
+    <img
+      mat-card-image
+      class="country-card-image"
+      [src]="country.flags.png"
+      [alt]="country.name"
+    />
+    <div *ngIf="worldCupRole" class="country-card-badges">
+      <span *ngIf="isChampion" class="country-card-badge country-card-badge-champion">
+        🏆 Champion
+      </span>
+      <span *ngIf="isHost" class="country-card-badge country-card-badge-host">
+        📍 Host
+      </span>
+    </div>
+  </div>
   <mat-card-content class="country-card-content">
     <p class="country-card-title"><strong>{{country.name}}</strong></p>
     <p class="country-card-text"><strong>Population: </strong>{{country.population | number:'1.0-0' }}</p>

--- a/src/app/features/home/components/country-card/country-card.component.scss
+++ b/src/app/features/home/components/country-card/country-card.component.scss
@@ -3,11 +3,40 @@
   box-shadow: 2px 3px 10px 1px rgba(0, 0, 0, 0.1);
   cursor: pointer;
 
+  .country-card-flag {
+    position: relative;
+  }
+
   .country-card-image {
     min-width: 300px;
     object-fit: cover;
     aspect-ratio: 16/9;
     box-shadow: 0 0 1px 1px rgba(0, 0, 0, 0.1);
+  }
+
+  .country-card-badges {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.25rem;
+
+    .country-card-badge {
+      padding: 0.15rem 0.5rem;
+      border-radius: 0.25rem;
+      font-size: 0.75rem;
+      font-weight: 800;
+      box-shadow: 0 0 4px 1px rgba(0, 0, 0, 0.2);
+      background-color: var(--mat-toolbar-container-background-color);
+      color: var(--mat-app-text-color);
+    }
+
+    .country-card-badge-champion {
+      background-color: hsl(45, 90%, 50%);
+      color: hsl(200, 15%, 8%);
+    }
   }
 
   .country-card-content {

--- a/src/app/features/home/components/country-card/country-card.component.ts
+++ b/src/app/features/home/components/country-card/country-card.component.ts
@@ -1,20 +1,30 @@
-import { DecimalPipe } from '@angular/common';
+import { DecimalPipe, NgIf } from '@angular/common';
 import { Component, Input } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { Router, RouterModule } from '@angular/router';
 import { CountryViewModel } from '@features/home/shared/models/countries.model';
+import { WorldCupRole } from '@features/home/shared/models/world-cups.model';
 
 @Component({
   selector: 'app-country-card',
   standalone: true,
   templateUrl: './country-card.component.html',
   styleUrl: './country-card.component.scss',
-  imports: [MatCardModule, RouterModule, DecimalPipe],
+  imports: [MatCardModule, RouterModule, DecimalPipe, NgIf],
 })
 export class CountryCardComponent {
   @Input() country: CountryViewModel = {} as CountryViewModel;
+  @Input() worldCupRole?: WorldCupRole;
 
   constructor(private router: Router) {}
+
+  get isHost(): boolean {
+    return this.worldCupRole === 'host' || this.worldCupRole === 'host-champion';
+  }
+
+  get isChampion(): boolean {
+    return this.worldCupRole === 'champion' || this.worldCupRole === 'host-champion';
+  }
 
   handleCountryDetail() {
     this.router.navigate([`country/${this.country.alpha3Code}`]);

--- a/src/app/features/home/home.component.html
+++ b/src/app/features/home/home.component.html
@@ -35,6 +35,29 @@
               <mat-icon matPrefix>close</mat-icon>
             </span>
           </mat-form-field>
+          <mat-form-field class="home-filter-world-cup" appearance="outline">
+            <mat-select
+              formControlName="worldCup"
+              placeholder="Filter by World Cup"
+              hideSingleSelectionIndicator
+            >
+              <mat-option [value]="null">All World Cups</mat-option>
+              <mat-option
+                *ngFor="let edition of worldCupEditions"
+                [value]="edition.year"
+              >
+                {{ edition.year }} — {{ edition.hostNames.join(", ") }}
+              </mat-option>
+            </mat-select>
+            <span
+              *ngIf="searchForm.get('worldCup')?.value"
+              class="home-filter-clear"
+              matSuffix
+              (click)="handleClearFilter()"
+            >
+              <mat-icon matPrefix>close</mat-icon>
+            </span>
+          </mat-form-field>
         </div>
       </form>
       <div class="home-country-cards">
@@ -42,6 +65,7 @@
           class="home-country-item"
           *ngFor="let country of $countries | async"
           [country]="country"
+          [worldCupRole]="getWorldCupRole(country)"
         ></app-country-card>
       </div>
     </div>

--- a/src/app/features/home/home.component.scss
+++ b/src/app/features/home/home.component.scss
@@ -18,7 +18,8 @@
       flex: 1 1 auto;
     }
 
-    .home-filter-regions {
+    .home-filter-regions,
+    .home-filter-world-cup {
       display: flex;
 
       .home-filter-clear {
@@ -32,6 +33,10 @@
           font-size: 18px;
         }
       }
+    }
+
+    .home-filter-world-cup {
+      margin-left: 1rem;
     }
   }
 
@@ -50,9 +55,14 @@
         width: 100%;
       }
 
-      .home-filter-regions {
+      .home-filter-regions,
+      .home-filter-world-cup {
         display: flex;
         width: 60%;
+      }
+
+      .home-filter-world-cup {
+        margin-left: 0;
       }
     }
 

--- a/src/app/features/home/home.component.ts
+++ b/src/app/features/home/home.component.ts
@@ -7,8 +7,10 @@ import { MatSelectModule } from '@angular/material/select';
 import { CountryCardComponent } from './components/country-card/country-card.component';
 import { debounceTime, distinctUntilChanged, Observable } from 'rxjs';
 import { CountryViewModel } from './shared/models/countries.model';
+import { WorldCupRole, WorldCupViewModel } from './shared/models/world-cups.model';
 import { CommonModule } from '@angular/common';
 import { CountryDataService } from './shared/country-data.service';
+import { WorldCupService } from './shared/world-cup.service';
 
 @Component({
   selector: 'app-home',
@@ -29,35 +31,73 @@ import { CountryDataService } from './shared/country-data.service';
 export class HomeComponent implements OnInit {
   searchForm!: FormGroup;
   $countries!: Observable<CountryViewModel[]>;
+  worldCupEditions: WorldCupViewModel[] = [];
+  selectedEdition?: WorldCupViewModel;
 
   constructor(
     private formBuilder: FormBuilder,
-    private countryDataService: CountryDataService
+    private countryDataService: CountryDataService,
+    private worldCupService: WorldCupService
   ) {}
 
   ngOnInit() {
     this.initializeForm();
     this.loadCountries();
+    this.loadWorldCups();
   }
 
   initializeForm() {
     this.searchForm = this.formBuilder.group({
       search: [null],
       region: [null],
+      worldCup: [null],
     });
 
     this.searchForm.valueChanges
       .pipe(debounceTime(500), distinctUntilChanged())
-      .subscribe((search) =>
-        this.countryDataService.filter(search?.search, search?.region)
-      );
+      .subscribe((search) => {
+        this.selectedEdition = this.worldCupEditions.find(
+          (edition) => edition.year === search?.worldCup
+        );
+        this.countryDataService.filter(
+          search?.search,
+          search?.region,
+          search?.worldCup
+        );
+      });
   }
 
   loadCountries() {
     this.$countries = this.countryDataService.getAll();
   }
 
+  loadWorldCups() {
+    this.worldCupService.getEditions().subscribe((editions) => {
+      this.worldCupEditions = editions;
+    });
+  }
+
   handleClearFilter() {
     this.searchForm.get('region')?.reset();
+    this.searchForm.get('worldCup')?.reset();
+  }
+
+  getWorldCupRole(country: CountryViewModel): WorldCupRole | undefined {
+    const edition = this.selectedEdition;
+    if (!edition) {
+      return undefined;
+    }
+    const isHost = edition.hosts.includes(country.alpha3Code);
+    const isChampion = edition.champion === country.alpha3Code;
+    if (isHost && isChampion) {
+      return 'host-champion';
+    }
+    if (isChampion) {
+      return 'champion';
+    }
+    if (isHost) {
+      return 'host';
+    }
+    return undefined;
   }
 }

--- a/src/app/features/home/shared/country-data.service.ts
+++ b/src/app/features/home/shared/country-data.service.ts
@@ -2,16 +2,22 @@ import { Injectable } from '@angular/core';
 import { CountryViewModel } from './models/countries.model';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { CountryService } from './country.service';
+import { WorldCupService } from './world-cup.service';
+import { WorldCupViewModel } from './models/world-cups.model';
 
 @Injectable()
 export class CountryDataService {
   private readonly _countries = new BehaviorSubject<CountryViewModel[]>([]);
   private countriesApi: CountryViewModel[] = [];
+  private worldCups: WorldCupViewModel[] = [];
   readonly countries = this._countries.asObservable();
-  constructor(countryService: CountryService) {
+  constructor(countryService: CountryService, worldCupService: WorldCupService) {
     countryService.getAll().subscribe((result) => {
       this.countriesApi = result;
       this._countries.next(result);
+    });
+    worldCupService.getEditions().subscribe((editions) => {
+      this.worldCups = editions;
     });
   }
 
@@ -19,8 +25,13 @@ export class CountryDataService {
     return this.countries;
   }
 
-  public filter(name?: string, region?: string) {
+  public filter(name?: string, region?: string, worldCupYear?: number) {
+    const participants = this.getParticipants(worldCupYear);
     let filteredCountries = this.countriesApi.filter((country) => {
+      if (participants && !participants.has(country.alpha3Code)) {
+        return false;
+      }
+
       if (name && region) {
         return (
           country.name.toLowerCase().startsWith(name.toLowerCase()) &&
@@ -39,5 +50,13 @@ export class CountryDataService {
       return true;
     });
     this._countries.next(filteredCountries);
+  }
+
+  private getParticipants(worldCupYear?: number): Set<string> | undefined {
+    if (!worldCupYear) {
+      return undefined;
+    }
+    const edition = this.worldCups.find((cup) => cup.year === worldCupYear);
+    return edition ? new Set(edition.participants) : undefined;
   }
 }

--- a/src/app/features/home/shared/models/world-cups.model.ts
+++ b/src/app/features/home/shared/models/world-cups.model.ts
@@ -1,0 +1,10 @@
+export interface WorldCupViewModel {
+  year: number;
+  hosts: string[];
+  hostNames: string[];
+  champion: string | null;
+  participants: string[];
+  historicalNames: Record<string, string>;
+}
+
+export type WorldCupRole = 'host' | 'champion' | 'host-champion';

--- a/src/app/features/home/shared/world-cup.service.ts
+++ b/src/app/features/home/shared/world-cup.service.ts
@@ -1,0 +1,29 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { map, Observable, shareReplay } from 'rxjs';
+import { WorldCupViewModel } from './models/world-cups.model';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class WorldCupService {
+  private readonly dataUrl = 'assets/world-cups.json';
+  private readonly editions$: Observable<WorldCupViewModel[]>;
+
+  constructor(httpClient: HttpClient) {
+    this.editions$ = httpClient.get<WorldCupViewModel[]>(this.dataUrl).pipe(
+      map((editions) => [...editions].sort((a, b) => b.year - a.year)),
+      shareReplay(1)
+    );
+  }
+
+  public getEditions(): Observable<WorldCupViewModel[]> {
+    return this.editions$;
+  }
+
+  public getByYear(year: number): Observable<WorldCupViewModel | undefined> {
+    return this.editions$.pipe(
+      map((editions) => editions.find((edition) => edition.year === year))
+    );
+  }
+}

--- a/src/assets/world-cups.json
+++ b/src/assets/world-cups.json
@@ -1,0 +1,186 @@
+[
+  {
+    "year": 1930,
+    "hosts": ["URY"],
+    "hostNames": ["Uruguay"],
+    "champion": "URY",
+    "participants": ["ARG", "BEL", "BOL", "BRA", "CHL", "FRA", "MEX", "PER", "PRY", "ROU", "SRB", "URY", "USA"],
+    "historicalNames": { "SRB": "Yugoslavia" }
+  },
+  {
+    "year": 1934,
+    "hosts": ["ITA"],
+    "hostNames": ["Italy"],
+    "champion": "ITA",
+    "participants": ["ARG", "AUT", "BEL", "BRA", "CHE", "CZE", "DEU", "EGY", "ESP", "FRA", "HUN", "ITA", "NLD", "ROU", "SWE", "USA"],
+    "historicalNames": { "CZE": "Czechoslovakia" }
+  },
+  {
+    "year": 1938,
+    "hosts": ["FRA"],
+    "hostNames": ["France"],
+    "champion": "ITA",
+    "participants": ["BEL", "BRA", "CHE", "CUB", "CZE", "DEU", "FRA", "HUN", "IDN", "ITA", "NLD", "NOR", "POL", "ROU", "SWE"],
+    "historicalNames": { "CZE": "Czechoslovakia", "IDN": "Dutch East Indies" }
+  },
+  {
+    "year": 1950,
+    "hosts": ["BRA"],
+    "hostNames": ["Brazil"],
+    "champion": "URY",
+    "participants": ["BOL", "BRA", "CHE", "CHL", "ESP", "GBR", "ITA", "MEX", "PRY", "SRB", "SWE", "URY", "USA"],
+    "historicalNames": { "GBR": "England", "SRB": "Yugoslavia" }
+  },
+  {
+    "year": 1954,
+    "hosts": ["CHE"],
+    "hostNames": ["Switzerland"],
+    "champion": "DEU",
+    "participants": ["AUT", "BEL", "BRA", "CHE", "CZE", "DEU", "FRA", "GBR", "HUN", "ITA", "KOR", "MEX", "SRB", "TUR", "URY"],
+    "historicalNames": { "CZE": "Czechoslovakia", "DEU": "West Germany", "GBR": "England, Scotland", "SRB": "Yugoslavia" }
+  },
+  {
+    "year": 1958,
+    "hosts": ["SWE"],
+    "hostNames": ["Sweden"],
+    "champion": "BRA",
+    "participants": ["ARG", "AUT", "BRA", "CZE", "DEU", "FRA", "GBR", "HUN", "MEX", "PRY", "RUS", "SRB", "SWE"],
+    "historicalNames": { "CZE": "Czechoslovakia", "DEU": "West Germany", "GBR": "England, Northern Ireland, Scotland, Wales", "RUS": "Soviet Union", "SRB": "Yugoslavia" }
+  },
+  {
+    "year": 1962,
+    "hosts": ["CHL"],
+    "hostNames": ["Chile"],
+    "champion": "BRA",
+    "participants": ["ARG", "BGR", "BRA", "CHE", "CHL", "COL", "CZE", "DEU", "ESP", "GBR", "HUN", "ITA", "MEX", "RUS", "SRB", "URY"],
+    "historicalNames": { "CZE": "Czechoslovakia", "DEU": "West Germany", "GBR": "England", "RUS": "Soviet Union", "SRB": "Yugoslavia" }
+  },
+  {
+    "year": 1966,
+    "hosts": ["GBR"],
+    "hostNames": ["England"],
+    "champion": "GBR",
+    "participants": ["ARG", "BGR", "BRA", "CHE", "CHL", "DEU", "ESP", "FRA", "GBR", "HUN", "ITA", "MEX", "PRK", "PRT", "RUS", "URY"],
+    "historicalNames": { "DEU": "West Germany", "GBR": "England", "RUS": "Soviet Union" }
+  },
+  {
+    "year": 1970,
+    "hosts": ["MEX"],
+    "hostNames": ["Mexico"],
+    "champion": "BRA",
+    "participants": ["BEL", "BGR", "BRA", "CZE", "DEU", "GBR", "ISR", "ITA", "MAR", "MEX", "PER", "ROU", "RUS", "SLV", "SWE", "URY"],
+    "historicalNames": { "CZE": "Czechoslovakia", "DEU": "West Germany", "GBR": "England", "RUS": "Soviet Union" }
+  },
+  {
+    "year": 1974,
+    "hosts": ["DEU"],
+    "hostNames": ["West Germany"],
+    "champion": "DEU",
+    "participants": ["ARG", "AUS", "BGR", "BRA", "CHL", "COD", "DEU", "GBR", "HTI", "ITA", "NLD", "POL", "SRB", "SWE", "URY"],
+    "historicalNames": { "COD": "Zaire", "DEU": "West Germany, East Germany", "GBR": "Scotland", "SRB": "Yugoslavia" }
+  },
+  {
+    "year": 1978,
+    "hosts": ["ARG"],
+    "hostNames": ["Argentina"],
+    "champion": "ARG",
+    "participants": ["ARG", "AUT", "BRA", "DEU", "ESP", "FRA", "GBR", "HUN", "IRN", "ITA", "MEX", "NLD", "PER", "POL", "SWE", "TUN"],
+    "historicalNames": { "DEU": "West Germany", "GBR": "Scotland" }
+  },
+  {
+    "year": 1982,
+    "hosts": ["ESP"],
+    "hostNames": ["Spain"],
+    "champion": "ITA",
+    "participants": ["ARG", "AUT", "BEL", "BRA", "CHL", "CMR", "CZE", "DEU", "DZA", "ESP", "FRA", "GBR", "HND", "HUN", "ITA", "KWT", "NZL", "PER", "POL", "RUS", "SLV", "SRB"],
+    "historicalNames": { "CZE": "Czechoslovakia", "DEU": "West Germany", "GBR": "England, Northern Ireland, Scotland", "RUS": "Soviet Union", "SRB": "Yugoslavia" }
+  },
+  {
+    "year": 1986,
+    "hosts": ["MEX"],
+    "hostNames": ["Mexico"],
+    "champion": "ARG",
+    "participants": ["ARG", "BEL", "BGR", "BRA", "CAN", "DEU", "DNK", "DZA", "ESP", "FRA", "GBR", "HUN", "IRQ", "ITA", "KOR", "MAR", "MEX", "POL", "PRT", "PRY", "RUS", "URY"],
+    "historicalNames": { "DEU": "West Germany", "GBR": "England, Northern Ireland, Scotland", "RUS": "Soviet Union" }
+  },
+  {
+    "year": 1990,
+    "hosts": ["ITA"],
+    "hostNames": ["Italy"],
+    "champion": "DEU",
+    "participants": ["ARE", "ARG", "AUT", "BEL", "BRA", "CMR", "COL", "CRI", "CZE", "DEU", "EGY", "ESP", "GBR", "IRL", "ITA", "KOR", "NLD", "ROU", "RUS", "SRB", "SWE", "URY", "USA"],
+    "historicalNames": { "CZE": "Czechoslovakia", "DEU": "West Germany", "GBR": "England, Scotland", "RUS": "Soviet Union", "SRB": "Yugoslavia" }
+  },
+  {
+    "year": 1994,
+    "hosts": ["USA"],
+    "hostNames": ["United States"],
+    "champion": "BRA",
+    "participants": ["ARG", "BEL", "BGR", "BOL", "BRA", "CHE", "CMR", "COL", "DEU", "ESP", "GRC", "IRL", "ITA", "KOR", "MAR", "MEX", "NGA", "NLD", "NOR", "ROU", "RUS", "SAU", "SWE", "USA"],
+    "historicalNames": {}
+  },
+  {
+    "year": 1998,
+    "hosts": ["FRA"],
+    "hostNames": ["France"],
+    "champion": "FRA",
+    "participants": ["ARG", "AUT", "BEL", "BGR", "BRA", "CHL", "CMR", "COL", "DEU", "DNK", "ESP", "FRA", "GBR", "HRV", "IRN", "ITA", "JAM", "JPN", "KOR", "MAR", "MEX", "NGA", "NLD", "NOR", "PRY", "ROU", "SAU", "SRB", "TUN", "USA", "ZAF"],
+    "historicalNames": { "GBR": "England, Scotland", "SRB": "FR Yugoslavia" }
+  },
+  {
+    "year": 2002,
+    "hosts": ["KOR", "JPN"],
+    "hostNames": ["South Korea", "Japan"],
+    "champion": "BRA",
+    "participants": ["ARG", "BEL", "BRA", "CHN", "CMR", "CRI", "DEU", "DNK", "ECU", "ESP", "FRA", "GBR", "HRV", "IRL", "ITA", "JPN", "KOR", "MEX", "NGA", "POL", "PRT", "PRY", "RUS", "SAU", "SEN", "SVN", "SWE", "TUN", "TUR", "URY", "USA", "ZAF"],
+    "historicalNames": { "GBR": "England" }
+  },
+  {
+    "year": 2006,
+    "hosts": ["DEU"],
+    "hostNames": ["Germany"],
+    "champion": "ITA",
+    "participants": ["AGO", "ARG", "AUS", "BRA", "CHE", "CIV", "CRI", "CZE", "DEU", "ECU", "ESP", "FRA", "GBR", "GHA", "HRV", "IRN", "ITA", "JPN", "KOR", "MEX", "NLD", "POL", "PRT", "PRY", "SAU", "SRB", "SWE", "TGO", "TTO", "TUN", "UKR", "USA"],
+    "historicalNames": { "GBR": "England", "SRB": "Serbia and Montenegro" }
+  },
+  {
+    "year": 2010,
+    "hosts": ["ZAF"],
+    "hostNames": ["South Africa"],
+    "champion": "ESP",
+    "participants": ["ARG", "AUS", "BRA", "CHE", "CHL", "CIV", "CMR", "DEU", "DNK", "DZA", "ESP", "FRA", "GBR", "GHA", "GRC", "HND", "ITA", "JPN", "KOR", "MEX", "NGA", "NLD", "NZL", "PRK", "PRT", "PRY", "SRB", "SVK", "SVN", "URY", "USA", "ZAF"],
+    "historicalNames": { "GBR": "England" }
+  },
+  {
+    "year": 2014,
+    "hosts": ["BRA"],
+    "hostNames": ["Brazil"],
+    "champion": "DEU",
+    "participants": ["ARG", "AUS", "BEL", "BIH", "BRA", "CHE", "CHL", "CIV", "CMR", "COL", "CRI", "DEU", "DZA", "ECU", "ESP", "FRA", "GBR", "GHA", "GRC", "HND", "HRV", "IRN", "ITA", "JPN", "KOR", "MEX", "NGA", "NLD", "PRT", "RUS", "URY", "USA"],
+    "historicalNames": { "GBR": "England" }
+  },
+  {
+    "year": 2018,
+    "hosts": ["RUS"],
+    "hostNames": ["Russia"],
+    "champion": "FRA",
+    "participants": ["ARG", "AUS", "BEL", "BRA", "CHE", "COL", "CRI", "DEU", "DNK", "EGY", "ESP", "FRA", "GBR", "HRV", "IRN", "ISL", "JPN", "KOR", "MAR", "MEX", "NGA", "PAN", "PER", "POL", "PRT", "RUS", "SAU", "SEN", "SRB", "SWE", "TUN", "URY"],
+    "historicalNames": { "GBR": "England" }
+  },
+  {
+    "year": 2022,
+    "hosts": ["QAT"],
+    "hostNames": ["Qatar"],
+    "champion": "ARG",
+    "participants": ["ARG", "AUS", "BEL", "BRA", "CAN", "CHE", "CMR", "CRI", "DEU", "DNK", "ECU", "ESP", "FRA", "GBR", "GHA", "HRV", "IRN", "JPN", "KOR", "MAR", "MEX", "NLD", "POL", "PRT", "QAT", "SAU", "SEN", "SRB", "TUN", "URY", "USA"],
+    "historicalNames": { "GBR": "England, Wales" }
+  },
+  {
+    "year": 2026,
+    "hosts": ["USA", "MEX", "CAN"],
+    "hostNames": ["United States", "Mexico", "Canada"],
+    "champion": null,
+    "participants": ["ARG", "AUS", "AUT", "BEL", "BIH", "BRA", "CAN", "CHE", "CIV", "COD", "COL", "CPV", "CUW", "CZE", "DEU", "DZA", "ECU", "EGY", "ESP", "FRA", "GBR", "GHA", "HRV", "HTI", "IRN", "IRQ", "JOR", "JPN", "KOR", "MAR", "MEX", "NLD", "NOR", "NZL", "PAN", "PRT", "PRY", "QAT", "SAU", "SEN", "SWE", "TUN", "TUR", "URY", "USA", "UZB", "ZAF"],
+    "historicalNames": { "GBR": "England, Scotland" }
+  }
+]


### PR DESCRIPTION
## Summary

Implements OpenSpec change `add-world-cup-filter` (proposal/design/specs/tasks in `openspec/changes/add-world-cup-filter/`, facts verified against FIFA records on 2026-06-12):

- **Dataset** `src/assets/world-cups.json`: all 23 FIFA World Cup editions (1930–2026); participants as deduplicated modern ISO alpha-3 codes; defunct states and UK home nations mapped to successors (`historicalNames` preserves original team names); `champion: null` for the ongoing 2026 edition
- **`WorldCupService`** (root-provided): loads the asset via HttpClient (spinner interceptor applies) with `shareReplay(1)`, editions ordered most recent first
- **Home filter**: new "Filter by World Cup" Material select (year + hosts label, "All World Cups" option), conjunctive with the existing search/region filters; clear-filter resets it too
- **Country cards**: 🏆 Champion / 📍 Host badges over the flag for the selected edition, themed for light and dark modes

## Test plan

- Dataset validated by script: 23 editions, zero orphan codes against `data.json`, anchor facts verified (1930 = URY host+champion, 13 participants; 1966 = GBR; 2002 = KOR+JPN; 2022 = ARG; 2026 = USA/MEX/CAN, no champion)
- Spec scenarios simulated against real data: 1930 → 13 countries (URY double badge); 2022 + Europe → 12 European participants; 2026 → 47 countries, 3 host badges, no champion; no edition → full list
- `npm run build` passes (pre-existing Material bundle budget warning only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)